### PR TITLE
fix(docker): bootstrap Claude auth for containerized phantom

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -78,6 +78,43 @@ fi
 # 5. Set Docker awareness flag
 export PHANTOM_DOCKER=true
 
-# 6. Start Phantom (exec replaces shell so signals reach Bun directly)
+# 6. Claude Max OAuth credentials (optional)
+#
+# Preferred path: set CLAUDE_CODE_OAUTH_TOKEN in .env (generated once via
+# `claude setup-token` inside the container). It is a long-lived token with
+# its own session, does not rotate, and will not conflict with any other
+# Claude Code sessions on the host or elsewhere.
+#
+# Fallback path: docker-compose.override.yml can bind-mount the host's
+# ~/.claude/.credentials.json read-only to /tmp/.credentials-mount.json, and
+# we copy it into place + keep it in sync via a background loop. WARNING:
+# this shares a rotating OAuth session between the host and the container,
+# which Anthropic's auth backend will reject as concurrent use. Only use the
+# mount fallback on machines where nothing else is running Claude Code.
+CLAUDE_CRED_SRC="/tmp/.credentials-mount.json"
+CLAUDE_CRED_DST="/home/phantom/.claude/.credentials.json"
+if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  echo "[phantom] Using CLAUDE_CODE_OAUTH_TOKEN from environment (skipping credentials mount)"
+elif [ -f "$CLAUDE_CRED_SRC" ]; then
+  echo "[phantom] Installing Claude Max credentials from mount..."
+  mkdir -p "$(dirname "$CLAUDE_CRED_DST")"
+  cp "$CLAUDE_CRED_SRC" "$CLAUDE_CRED_DST"
+  chmod 600 "$CLAUDE_CRED_DST"
+
+  (
+    while sleep 60; do
+      if [ -f "$CLAUDE_CRED_SRC" ] && ! cmp -s "$CLAUDE_CRED_SRC" "$CLAUDE_CRED_DST" 2>/dev/null; then
+        if cp "$CLAUDE_CRED_SRC" "$CLAUDE_CRED_DST" 2>/dev/null; then
+          chmod 600 "$CLAUDE_CRED_DST" 2>/dev/null || true
+          echo "[phantom] Claude credentials refreshed from mount"
+        fi
+      fi
+    done
+  ) &
+else
+  echo "[phantom] No Claude Max credentials mount found at $CLAUDE_CRED_SRC (relying on ANTHROPIC_API_KEY)"
+fi
+
+# 7. Start Phantom (exec replaces shell so signals reach Bun directly)
 echo "[phantom] Starting Phantom..."
 exec bun run src/index.ts


### PR DESCRIPTION
## Summary

The Docker entrypoint never installed Claude authentication credentials, so every container recreate booted without them and phantom responded with \"please /login\" to any Slack message. Additionally, the original bind-mount approach documented in \`docker-compose.override.yml\` shared a rotating OAuth session between host and container, which the Anthropic auth backend rejects as concurrent use — the CLI then deletes its own credentials file to force a re-login, breaking phantom a second time.

## Two paths in the entrypoint

1. **Preferred: \`CLAUDE_CODE_OAUTH_TOKEN\` in \`.env\`**, generated once via \`claude setup-token\` inside the container. Long-lived (1 year), its own session, never rotates, never conflicts with a Claude Code session on the host. Skips the mount entirely.
2. **Fallback: bind-mount the host's \`~/.claude/.credentials.json\`** to \`/tmp/.credentials-mount.json\`. Entrypoint installs it into \`/home/phantom/.claude/\` with 600 perms and starts a background loop that re-copies when the host file changes. The comment in the script warns that this path is only safe when nothing else on the host is running Claude Code.

Auth priority: token env var > credentials mount > neither (prints a message that \`ANTHROPIC_API_KEY\` is expected).

## Root cause diagnostic

Before this fix, phantom was asking for \`/login\` in Slack. Investigation timeline:

- \`/home/phantom/.claude/.credentials.json\` was missing despite the container being up for 53 minutes with no restart
- Host credentials file unchanged, token valid for 4+ more hours
- Parent dir mtime confirmed deletion at 03:41:37, 3 minutes after a successful SDK call
- Diagnosis: the container's \`claude\` CLI subprocess got a 401 from the auth backend (concurrent use rejection) and its error-handling path deleted the credentials file

Restoring the file manually would just replay the same failure on the next SDK call while the host's Claude Code was active. The env-var path sidesteps it entirely.

## Test plan

- [x] \`bash -n scripts/docker-entrypoint.sh\` syntax clean
- [x] Rebuild phantom image and recreate container with \`CLAUDE_CODE_OAUTH_TOKEN\` in \`.env\` — startup log shows \`Using CLAUDE_CODE_OAUTH_TOKEN from environment (skipping credentials mount)\`
- [x] No credentials file written under \`/home/phantom/.claude/\`
- [x] SDK sanity call succeeds: \`bun -e 'query({prompt:...})'\` returns result with \`subtype: success\`
- [x] Slack connection establishes cleanly
- [ ] Confirm long-term: token still works after 24h of Slack activity (pending real-world soak)