### PR TITLE
fix(evolution): support OAuth tokens for LLM judge auth

### DIFF
--- a/src/evolution/engine.ts
+++ b/src/evolution/engine.ts
@@ -48,7 +48,7 @@ export class EvolutionEngine {
 		const setting = this.config.judges?.enabled ?? "auto";
 		if (setting === "never") return false;
 		if (setting === "always") return true;
-		return !!process.env.ANTHROPIC_API_KEY;
+		return !!(process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN || process.env.CLAUDE_CODE_OAUTH_TOKEN);
 	}
 
 	usesLLMJudges(): boolean {

--- a/src/evolution/judges/client.ts
+++ b/src/evolution/judges/client.ts
@@ -14,7 +14,8 @@ let _client: Anthropic | null = null;
 
 function getClient(): Anthropic {
 	if (!_client) {
-		_client = new Anthropic();
+		const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.CLAUDE_CODE_OAUTH_TOKEN || undefined;
+		_client = authToken && !process.env.ANTHROPIC_API_KEY ? new Anthropic({ authToken }) : new Anthropic();
 	}
 	return _client;
 }
@@ -25,7 +26,7 @@ export function setClient(client: Anthropic | null): void {
 }
 
 export function isJudgeAvailable(): boolean {
-	return !!process.env.ANTHROPIC_API_KEY;
+	return !!(process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN || process.env.CLAUDE_CODE_OAUTH_TOKEN);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `resolveJudgeMode()`, `getClient()`, and `isJudgeAvailable()` now check `ANTHROPIC_AUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` in addition to `ANTHROPIC_API_KEY`
- Enables LLM judges (critique, consolidation, evolution validation) on Max subscription deployments that use OAuth bearer tokens instead of API keys
- Fork-only change - not intended for upstream

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] 47 judge tests pass
- [x] Deployed to container, logs confirm: `[evolution] LLM judges enabled (API key detected)`