### PR TITLE
feat: bound phantom_loop ticks with a wall-clock timeout

### DIFF
--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -65,6 +65,7 @@ export class AgentRuntime {
 		conversationId: string,
 		text: string,
 		onEvent?: (event: RuntimeEvent) => void,
+		externalSignal?: AbortSignal,
 	): Promise<AgentResponse> {
 		const sessionKey = `${channelId}:${conversationId}`;
 		const startTime = Date.now();
@@ -83,10 +84,31 @@ export class AgentRuntime {
 		const wrappedText = this.isExternalChannel(channelId) ? this.wrapWithSecurityContext(text) : text;
 
 		try {
-			return await this.runQuery(sessionKey, channelId, conversationId, wrappedText, startTime, onEvent);
+			return await this.runQuery(
+				sessionKey,
+				channelId,
+				conversationId,
+				wrappedText,
+				startTime,
+				onEvent,
+				externalSignal,
+			);
 		} finally {
 			this.activeSessions.delete(sessionKey);
 		}
+	}
+
+	/**
+	 * Drop an in-flight session from the activeSessions bookkeeping without
+	 * waiting for handleMessage's finally block. Used by LoopRunner on a hard
+	 * timeout: when the SDK iterator is wedged (e.g. `docker exec` ignoring
+	 * signals), the orphan handleMessage promise will never resolve and its
+	 * own finally will never fire. Without this, every subsequent tick for the
+	 * same (channelId, conversationId) pair would be silently deduped by the
+	 * activeSessions guard. Idempotent: deleting a missing key is a no-op.
+	 */
+	releaseSession(channelId: string, conversationId: string): void {
+		this.activeSessions.delete(`${channelId}:${conversationId}`);
 	}
 
 	// Scheduler, trigger, and loop are internal sources; all other channels are external user input
@@ -110,6 +132,7 @@ export class AgentRuntime {
 		text: string,
 		startTime: number,
 		onEvent?: (event: RuntimeEvent) => void,
+		externalSignal?: AbortSignal,
 	): Promise<AgentResponse> {
 		let session = this.sessionStore.findActive(channelId, conversationId);
 		const isResume = session?.sdk_session_id != null;
@@ -136,6 +159,21 @@ export class AgentRuntime {
 		const controller = new AbortController();
 		const timeoutMs = (this.config.timeout_minutes ?? 240) * 60 * 1000;
 		const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+		// Bridge an optional caller-supplied signal into the SDK controller.
+		// LoopRunner uses this for per-tick wall-clock caps layered on top of
+		// the existing config.timeout_minutes guard. `once: true` so the
+		// listener auto-detaches after firing; we also remove it explicitly in
+		// the finally to cover the no-abort success path.
+		let externalAbortListener: (() => void) | undefined;
+		if (externalSignal) {
+			if (externalSignal.aborted) {
+				controller.abort();
+			} else {
+				externalAbortListener = () => controller.abort();
+				externalSignal.addEventListener("abort", externalAbortListener, { once: true });
+			}
+		}
 		let sdkSessionId = "";
 		let resultText = "";
 		let cost: AgentCost = emptyCost();
@@ -245,6 +283,9 @@ export class AgentRuntime {
 			}
 		} finally {
 			clearTimeout(timeout);
+			if (externalSignal && externalAbortListener) {
+				externalSignal.removeEventListener("abort", externalAbortListener);
+			}
 		}
 
 		this.lastTrackedFiles = fileTracker.getTrackedFiles();

--- a/src/db/__tests__/migrate.test.ts
+++ b/src/db/__tests__/migrate.test.ts
@@ -36,7 +36,7 @@ describe("runMigrations", () => {
 		runMigrations(db);
 
 		const migrationCount = db.query("SELECT COUNT(*) as count FROM _migrations").get() as { count: number };
-		expect(migrationCount.count).toBe(13);
+		expect(migrationCount.count).toBe(14);
 	});
 
 	test("tracks applied migration indices", () => {
@@ -48,6 +48,6 @@ describe("runMigrations", () => {
 			.all()
 			.map((r) => (r as { index_num: number }).index_num);
 
-		expect(indices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+		expect(indices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 	});
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -128,4 +128,9 @@ export const MIGRATIONS: string[] = [
 	"ALTER TABLE loops ADD COLUMN trigger_message_ts TEXT",
 
 	"ALTER TABLE loops ADD COLUMN checkpoint_interval INTEGER",
+
+	// Per-tick wall-clock cap (ms). Default 1_800_000 = 30 minutes matches
+	// LOOP_DEFAULT_MAX_TICK_DURATION_MS in src/loop/types.ts. Backfilled by
+	// the DEFAULT clause for existing rows so the runner never sees NULL.
+	"ALTER TABLE loops ADD COLUMN max_tick_duration_ms INTEGER NOT NULL DEFAULT 1800000",
 ];

--- a/src/loop/__tests__/evolution-integration.test.ts
+++ b/src/loop/__tests__/evolution-integration.test.ts
@@ -25,7 +25,10 @@ function createMockRuntime(impl?: HandleMessageImpl) {
 		cost: { totalUsd: 0.01, inputTokens: 10, outputTokens: 10, modelUsage: {} },
 		durationMs: 10,
 	});
-	return { handleMessage: mock(impl ?? defaultImpl) };
+	return {
+		handleMessage: mock(impl ?? defaultImpl),
+		releaseSession: mock(() => {}),
+	};
 }
 
 function agentFinishes(stateFile: string, loopId: string): HandleMessageImpl {

--- a/src/loop/__tests__/notifications.test.ts
+++ b/src/loop/__tests__/notifications.test.ts
@@ -41,6 +41,7 @@ function makeLoop(overrides: Partial<Loop> = {}): Loop {
 		successCommand: null,
 		maxIterations: 10,
 		maxCostUsd: 5,
+		maxTickDurationMs: 30 * 60 * 1000,
 		checkpointInterval: null,
 		status: "running",
 		iterationCount: 0,
@@ -86,6 +87,7 @@ describe("terminalEmoji", () => {
 		expect(terminalEmoji("stopped")).toBe(":octagonal_sign:");
 		expect(terminalEmoji("budget_exceeded")).toBe(":warning:");
 		expect(terminalEmoji("failed")).toBe(":x:");
+		expect(terminalEmoji("timed_out")).toBe(":alarm_clock:");
 		expect(terminalEmoji("running")).toBe(":repeat:");
 	});
 });
@@ -132,6 +134,7 @@ describe("LoopNotifier", () => {
 				successCommand: null,
 				maxIterations: 10,
 				maxCostUsd: 5,
+				maxTickDurationMs: 30 * 60 * 1000,
 				channelId: "C100",
 				conversationId: "1700000000.000100",
 				triggerMessageTs: "1700000000.000200",
@@ -173,6 +176,7 @@ describe("LoopNotifier", () => {
 				successCommand: null,
 				maxIterations: 10,
 				maxCostUsd: 5,
+				maxTickDurationMs: 30 * 60 * 1000,
 				channelId: "C100",
 				conversationId: null,
 				triggerMessageTs: null,
@@ -195,6 +199,7 @@ describe("LoopNotifier", () => {
 				successCommand: null,
 				maxIterations: 10,
 				maxCostUsd: 5,
+				maxTickDurationMs: 30 * 60 * 1000,
 				channelId: "C100",
 				conversationId: "1700000000.000100",
 				triggerMessageTs: overrides.triggerMessageTs ?? "1700000000.000200",
@@ -271,6 +276,7 @@ describe("LoopNotifier", () => {
 				successCommand: null,
 				maxIterations: 10,
 				maxCostUsd: 5,
+				maxTickDurationMs: 30 * 60 * 1000,
 				channelId: "C100",
 				conversationId: null,
 				triggerMessageTs: "1700000000.000200",

--- a/src/loop/__tests__/post-loop.test.ts
+++ b/src/loop/__tests__/post-loop.test.ts
@@ -11,6 +11,7 @@ function makeLoop(overrides: Partial<Loop> = {}): Loop {
 		successCommand: null,
 		maxIterations: 20,
 		maxCostUsd: 5,
+		maxTickDurationMs: 30 * 60 * 1000,
 		checkpointInterval: null,
 		status: "running",
 		iterationCount: 5,

--- a/src/loop/__tests__/prompt.test.ts
+++ b/src/loop/__tests__/prompt.test.ts
@@ -11,6 +11,7 @@ function makeLoop(overrides: Partial<Loop> = {}): Loop {
 		successCommand: null,
 		maxIterations: 20,
 		maxCostUsd: 5,
+		maxTickDurationMs: 30 * 60 * 1000,
 		checkpointInterval: null,
 		status: "running",
 		iterationCount: 3,

--- a/src/loop/__tests__/runner.test.ts
+++ b/src/loop/__tests__/runner.test.ts
@@ -3,19 +3,24 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { RuntimeEvent } from "../../agent/runtime.ts";
 import { runMigrations } from "../../db/migrate.ts";
 import { LoopRunner } from "../runner.ts";
+
+type MockResponse = {
+	text: string;
+	sessionId: string;
+	cost: { totalUsd: number; inputTokens: number; outputTokens: number; modelUsage: Record<string, never> };
+	durationMs: number;
+};
 
 type HandleMessageImpl = (
 	channel: string,
 	conversationId: string,
 	text: string,
-) => Promise<{
-	text: string;
-	sessionId: string;
-	cost: { totalUsd: number; inputTokens: number; outputTokens: number; modelUsage: Record<string, never> };
-	durationMs: number;
-}>;
+	onEvent?: (event: RuntimeEvent) => void,
+	externalSignal?: AbortSignal,
+) => Promise<MockResponse>;
 
 function createMockRuntime(impl?: HandleMessageImpl) {
 	const defaultImpl: HandleMessageImpl = async () => ({
@@ -24,8 +29,15 @@ function createMockRuntime(impl?: HandleMessageImpl) {
 		cost: { totalUsd: 0.01, inputTokens: 10, outputTokens: 10, modelUsage: {} },
 		durationMs: 10,
 	});
+	// Tracks activeSessions in the same way AgentRuntime does, so tests can
+	// assert that releaseSession is called on the hard-cancel path.
+	const activeSessions = new Set<string>();
 	return {
 		handleMessage: mock(impl ?? defaultImpl),
+		releaseSession: mock((channelId: string, conversationId: string) => {
+			activeSessions.delete(`${channelId}:${conversationId}`);
+		}),
+		activeSessions,
 	};
 }
 
@@ -332,5 +344,139 @@ describe("LoopRunner", () => {
 
 		await runner.tick(loop.id);
 		expect(runner.getLoop(loop.id)?.status).toBe("running");
+	});
+
+	test("successful tick passes onEvent and abort signal to handleMessage (5-arg shape)", async () => {
+		const runtime = createMockRuntime();
+		const runner = new LoopRunner({ db, runtime: runtime, dataDir, autoSchedule: false });
+		const loop = runner.start({ goal: "5-arg" });
+		runtime.handleMessage.mockImplementation(agentFinishes(loop.stateFile, loop.id));
+
+		await runner.tick(loop.id);
+
+		expect(runtime.handleMessage).toHaveBeenCalledTimes(1);
+		const call = runtime.handleMessage.mock.calls[0];
+		expect(call[0]).toBe("loop");
+		expect(call[1]).toBe(`${loop.id}:0`);
+		expect(typeof call[3]).toBe("function"); // onEvent
+		// 5th arg is an AbortSignal (or at least an AbortSignal-like shape).
+		// Use duck-typing so we don't assume exact constructor identity across
+		// test environments.
+		const maybeSignal = call[4] as { aborted?: boolean; addEventListener?: unknown } | undefined;
+		expect(maybeSignal).toBeDefined();
+		expect(typeof maybeSignal?.aborted).toBe("boolean");
+		expect(typeof maybeSignal?.addEventListener).toBe("function");
+	});
+
+	test("soft timeout: mock resolves when signal aborts → status timed_out, releaseSession NOT called", async () => {
+		// Mock that cooperatively resolves when the tick's abort signal fires,
+		// simulating the SDK catching the abort and returning a normal-looking
+		// response with error text (exactly what runtime.ts does today).
+		const softImpl: HandleMessageImpl = async (_c, _cv, _t, _onEvent, signal) => {
+			await new Promise<void>((resolve) => {
+				if (signal?.aborted) {
+					resolve();
+					return;
+				}
+				signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+			return {
+				text: "Error: aborted",
+				sessionId: "s",
+				cost: { totalUsd: 0.01, inputTokens: 1, outputTokens: 1, modelUsage: {} },
+				durationMs: 1,
+			};
+		};
+		const runtime = createMockRuntime(softImpl);
+		const runner = new LoopRunner({
+			db,
+			runtime: runtime,
+			dataDir,
+			autoSchedule: false,
+			hardCancelGraceMs: 1_000, // big enough that hard never fires
+		});
+		const loop = runner.start({ goal: "soft", maxTickDurationMs: 50 });
+
+		await runner.tick(loop.id);
+
+		const final = runner.getLoop(loop.id);
+		expect(final?.status).toBe("timed_out");
+		expect(final?.lastError ?? "").toContain("soft-timed-out");
+		expect(runtime.releaseSession).not.toHaveBeenCalled();
+	});
+
+	test("hard timeout: mock never resolves → status timed_out, releaseSession called exactly once", async () => {
+		// Mock that ignores the abort signal entirely (simulates docker exec
+		// swallowing signals) — handleMessage never resolves or rejects.
+		const wedgedImpl: HandleMessageImpl = () => new Promise(() => {});
+		const runtime = createMockRuntime(wedgedImpl);
+		const runner = new LoopRunner({
+			db,
+			runtime: runtime,
+			dataDir,
+			autoSchedule: false,
+			hardCancelGraceMs: 30,
+		});
+		const loop = runner.start({ goal: "wedge", maxTickDurationMs: 50 });
+
+		await runner.tick(loop.id);
+
+		const final = runner.getLoop(loop.id);
+		expect(final?.status).toBe("timed_out");
+		expect(final?.lastError ?? "").toContain("hard-timed-out");
+		expect(runtime.releaseSession).toHaveBeenCalledTimes(1);
+		const releaseCall = runtime.releaseSession.mock.calls[0];
+		expect(releaseCall[0]).toBe("loop");
+		expect(releaseCall[1]).toBe(`${loop.id}:0`);
+	});
+
+	test("autoSchedule: no re-tick after timeout (handleMessage called exactly once)", async () => {
+		const wedgedImpl: HandleMessageImpl = () => new Promise(() => {});
+		const runtime = createMockRuntime(wedgedImpl);
+		const runner = new LoopRunner({
+			db,
+			runtime: runtime,
+			dataDir,
+			autoSchedule: true,
+			hardCancelGraceMs: 30,
+		});
+		const loop = runner.start({ goal: "auto-timeout", maxIterations: 5, maxTickDurationMs: 50 });
+
+		// Wait for the loop to finalize. Budget ~150ms: 50ms soft + 30ms hard + padding.
+		let reached = false;
+		for (let i = 0; i < 30; i++) {
+			if (runner.getLoop(loop.id)?.status === "timed_out") {
+				reached = true;
+				break;
+			}
+			await Bun.sleep(20);
+		}
+		expect(reached).toBe(true);
+		// Crucial assertion: even with autoSchedule true and max_iterations 5,
+		// a timeout must terminate the loop instead of triggering a new tick.
+		expect(runtime.handleMessage).toHaveBeenCalledTimes(1);
+	});
+
+	test("softTimerFired correctness: unrelated SDK error becomes 'failed', not 'timed_out'", async () => {
+		// Mock rejects immediately, long before the soft timer could fire.
+		const errorImpl: HandleMessageImpl = async () => {
+			throw new Error("Unrelated SDK explosion");
+		};
+		const runtime = createMockRuntime(errorImpl);
+		const runner = new LoopRunner({ db, runtime: runtime, dataDir, autoSchedule: false });
+		const loop = runner.start({ goal: "boom" });
+
+		// scheduleTick's catch handler is what turns rejections into "failed".
+		// Since autoSchedule is false here, we invoke tick directly and expect
+		// it to rethrow so the test runner sees the error; the runner only
+		// calls finalize(..., "failed") from scheduleTick's catch.
+		await expect(runner.tick(loop.id)).rejects.toThrow("Unrelated SDK explosion");
+
+		const final = runner.getLoop(loop.id);
+		// Still "running" because scheduleTick isn't in the loop here. The
+		// point of this test is that softTimerFired was false, so the catch
+		// path correctly rethrew instead of finalizing as timed_out.
+		expect(final?.status).toBe("running");
+		expect(final?.lastError).toBeNull();
 	});
 });

--- a/src/loop/__tests__/tool.test.ts
+++ b/src/loop/__tests__/tool.test.ts
@@ -16,6 +16,7 @@ function mockRuntime() {
 			cost: { totalUsd: 0.01, inputTokens: 1, outputTokens: 1, modelUsage: {} },
 			durationMs: 1,
 		})),
+		releaseSession: mock(() => {}),
 	};
 }
 

--- a/src/loop/notifications.ts
+++ b/src/loop/notifications.ts
@@ -16,6 +16,7 @@ const TERMINAL_REACTION: Partial<Record<LoopStatus, string>> = {
 	stopped: "octagonal_sign",
 	budget_exceeded: "warning",
 	failed: "x",
+	timed_out: "alarm_clock",
 };
 
 const REACTION_START = "hourglass_flowing_sand";

--- a/src/loop/prompt.ts
+++ b/src/loop/prompt.ts
@@ -75,6 +75,20 @@ BUDGETS (enforced by the runner, informational for you)
 - Iterations used so far: ${loop.iterationCount}
 - Cost used so far: $${loop.totalCostUsd.toFixed(4)}
 
+TIMEOUTS (this tick will be hard-cancelled if it runs too long)
+
+- This tick has at most ${Math.round(loop.maxTickDurationMs / 1000)} seconds of wall-clock
+  time. If the runner kills the tick mid-flight, its work is lost and the
+  loop is finalized as "timed_out".
+- Signals do NOT propagate through \`docker exec\`. If you run a long command
+  inside a container, wrap it with the host \`timeout\` utility so it cannot
+  wedge the tick, e.g.
+      timeout 300s docker exec my-container pytest
+  (choose a duration well under the tick budget above).
+- Prefer many small bash invocations over one giant blocking call. A single
+  unresponsive subprocess can burn the entire tick budget with nothing to
+  show for it.
+
 INSTRUCTIONS FOR THIS TICK
 
 1. Read the current state file (above) carefully. Understand what the previous

--- a/src/loop/runner.ts
+++ b/src/loop/runner.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import { join, relative, resolve } from "node:path";
-import type { AgentRuntime } from "../agent/runtime.ts";
+import type { AgentRuntime, RuntimeEvent } from "../agent/runtime.ts";
 import type { SlackChannel } from "../channels/slack.ts";
 import { buildSafeEnv } from "../mcp/dynamic-handlers.ts";
 import type { MemoryContextBuilder } from "../memory/context-builder.ts";
@@ -21,6 +21,7 @@ import { LoopStore } from "./store.ts";
 import {
 	LOOP_DEFAULT_MAX_COST_USD,
 	LOOP_DEFAULT_MAX_ITERATIONS,
+	LOOP_DEFAULT_MAX_TICK_DURATION_MS,
 	LOOP_MAX_COST_CEILING_USD,
 	LOOP_MAX_ITERATIONS_CEILING,
 	type Loop,
@@ -29,7 +30,7 @@ import {
 } from "./types.ts";
 
 /** Narrowed runtime interface for testability. */
-type LoopRuntime = Pick<AgentRuntime, "handleMessage">;
+type LoopRuntime = Pick<AgentRuntime, "handleMessage" | "releaseSession">;
 
 type RunnerDeps = {
 	db: Database;
@@ -40,9 +41,12 @@ type RunnerDeps = {
 	postLoopDeps?: PostLoopDeps;
 	/** Tests set to false to drive ticks deterministically. */
 	autoSchedule?: boolean;
+	/** Extra grace window after the soft abort before the hard cancel fires. */
+	hardCancelGraceMs?: number;
 };
 
 const SUCCESS_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_HARD_CANCEL_GRACE_MS = 30 * 1000;
 
 /** start -> tick (N times) -> finalize. State file is the agent's memory across ticks. */
 export class LoopRunner {
@@ -51,6 +55,7 @@ export class LoopRunner {
 	private slackChannel: SlackChannel | undefined;
 	private dataDir: string;
 	private autoSchedule: boolean;
+	private hardCancelGraceMs: number;
 	private inFlight = new Set<string>();
 	private notifier: LoopNotifier;
 	private memoryContextBuilder: MemoryContextBuilder | undefined;
@@ -65,6 +70,7 @@ export class LoopRunner {
 		this.slackChannel = deps.slackChannel;
 		this.dataDir = deps.dataDir ?? resolve(process.cwd(), "data");
 		this.autoSchedule = deps.autoSchedule ?? true;
+		this.hardCancelGraceMs = deps.hardCancelGraceMs ?? DEFAULT_HARD_CANCEL_GRACE_MS;
 		this.notifier = new LoopNotifier(this.slackChannel ?? null, this.store);
 		this.memoryContextBuilder = deps.memoryContextBuilder;
 		this.postLoopDeps = deps.postLoopDeps;
@@ -94,6 +100,11 @@ export class LoopRunner {
 
 		const maxIterations = clamp(input.maxIterations ?? LOOP_DEFAULT_MAX_ITERATIONS, 1, LOOP_MAX_ITERATIONS_CEILING);
 		const maxCostUsd = clamp(input.maxCostUsd ?? LOOP_DEFAULT_MAX_COST_USD, 0.01, LOOP_MAX_COST_CEILING_USD);
+		// maxTickDurationMs is trusted from the caller: the tool boundary (Zod
+		// in tool.ts) enforces the 1-60 minute window. Tests need to pass very
+		// small values to exercise the timeout path without sleeping a minute,
+		// so clamping here would force an awkward test-only override.
+		const maxTickDurationMs = input.maxTickDurationMs ?? LOOP_DEFAULT_MAX_TICK_DURATION_MS;
 
 		initStateFile(stateFile, id, input.goal);
 
@@ -105,6 +116,7 @@ export class LoopRunner {
 			successCommand: input.successCommand ?? null,
 			maxIterations,
 			maxCostUsd,
+			maxTickDurationMs,
 			checkpointInterval: input.checkpointInterval ?? null,
 			channelId: input.channelId ?? null,
 			conversationId: input.conversationId ?? null,
@@ -182,9 +194,85 @@ export class LoopRunner {
 			});
 
 			const conversationId = `${loop.id}:${loop.iterationCount}`;
-			const response = await this.runtime.handleMessage("loop", conversationId, prompt);
 
-			const addedCost = response.cost.totalUsd;
+			// Two-layer cancel. The soft abort gives the SDK a chance to clean
+			// up cooperatively; the hard race is the escape hatch for wedged
+			// subprocesses (notably `docker exec` swallowing signals).
+			const tickController = new AbortController();
+			let softTimerFired = false;
+			let lastTool: string | null = null;
+			const tickStartMs = Date.now();
+
+			const onEvent = (e: RuntimeEvent): void => {
+				if (e.type === "tool_use") lastTool = e.tool;
+			};
+
+			const softTimer = setTimeout(() => {
+				softTimerFired = true;
+				tickController.abort();
+			}, loop.maxTickDurationMs);
+
+			const hardTimeoutMs = loop.maxTickDurationMs + this.hardCancelGraceMs;
+			let hardTimer: ReturnType<typeof setTimeout> | undefined;
+			const hardTimeout = new Promise<never>((_, reject) => {
+				hardTimer = setTimeout(() => {
+					reject(new Error(`HARD_TIMEOUT after ${hardTimeoutMs}ms (lastTool=${lastTool ?? "none"})`));
+				}, hardTimeoutMs);
+			});
+
+			const messagePromise = this.runtime.handleMessage("loop", conversationId, prompt, onEvent, tickController.signal);
+			// If the hard-timeout wins the race, messagePromise is left dangling
+			// and a later rejection from it would become an unhandled rejection.
+			// Attach a no-op catch handler now; Promise.race below still sees the
+			// original rejection because it registered its own handler too.
+			messagePromise.catch(() => {});
+
+			let response: Awaited<ReturnType<LoopRuntime["handleMessage"]>> | null = null;
+			let raceError: unknown = null;
+			try {
+				response = (await Promise.race([messagePromise, hardTimeout])) as Awaited<
+					ReturnType<LoopRuntime["handleMessage"]>
+				>;
+			} catch (e: unknown) {
+				raceError = e;
+			}
+			clearTimeout(softTimer);
+			if (hardTimer) clearTimeout(hardTimer);
+
+			const raceMsg = raceError instanceof Error ? raceError.message : raceError ? String(raceError) : "";
+			const hardTimedOut = raceMsg.startsWith("HARD_TIMEOUT");
+
+			// softTimerFired guards the case where the SDK aborted cooperatively
+			// and returned a normal-looking response with an error-text body. The
+			// race resolves without throwing, so we must check the flag even on
+			// the success path — otherwise we'd call recordTick + re-read the
+			// state file on a tick that actually timed out.
+			if (softTimerFired || hardTimedOut) {
+				// A hard cancel means the orphan handleMessage promise will never
+				// resolve, so its own finally block will never drop the
+				// activeSessions entry. Release it here so subsequent ticks on
+				// the same conversation id can proceed. The soft path doesn't
+				// need this: the SDK already returned and its finally ran.
+				if (hardTimedOut) {
+					this.runtime.releaseSession("loop", conversationId);
+				}
+				const elapsedMs = Date.now() - tickStartMs;
+				const kind = hardTimedOut ? "hard" : "soft";
+				const detail = `Tick ${kind}-timed-out after ${elapsedMs}ms (limit ${loop.maxTickDurationMs}ms, lastTool=${lastTool ?? "none"})`;
+				this.finalize(id, "timed_out", detail);
+				return;
+			}
+
+			if (raceError) {
+				// Unrelated SDK failure: rethrow so scheduleTick's catch routes
+				// it to finalize(..., "failed", ...).
+				throw raceError;
+			}
+
+			// Control-flow invariant: reaching this point means the race resolved
+			// successfully (no throw, no timeout), so `response` is non-null.
+			const resolvedResponse = response as NonNullable<typeof response>;
+			const addedCost = resolvedResponse.cost.totalUsd;
 			const nextIteration = loop.iterationCount + 1;
 			this.store.recordTick(id, nextIteration, addedCost);
 
@@ -193,7 +281,7 @@ export class LoopRunner {
 			const frontmatter = parseFrontmatter(updatedContents);
 
 			// Track bounded transcript for post-loop evolution
-			recordTranscript(this.transcripts, id, nextIteration, prompt, response.text, frontmatter?.status);
+			recordTranscript(this.transcripts, id, nextIteration, prompt, resolvedResponse.text, frontmatter?.status);
 
 			if (frontmatter?.status === "done") {
 				this.finalize(id, "done", null);

--- a/src/loop/store.ts
+++ b/src/loop/store.ts
@@ -9,6 +9,7 @@ export type LoopInsertInput = {
 	successCommand: string | null;
 	maxIterations: number;
 	maxCostUsd: number;
+	maxTickDurationMs: number;
 	checkpointInterval?: number | null;
 	channelId: string | null;
 	conversationId: string | null;
@@ -24,8 +25,8 @@ export class LoopStore {
 
 	insert(input: LoopInsertInput): Loop {
 		this.db.run(
-			`INSERT INTO loops (id, goal, workspace_dir, state_file, success_command, max_iterations, max_cost_usd, checkpoint_interval, status, channel_id, conversation_id, trigger_message_ts)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)`,
+			`INSERT INTO loops (id, goal, workspace_dir, state_file, success_command, max_iterations, max_cost_usd, max_tick_duration_ms, checkpoint_interval, status, channel_id, conversation_id, trigger_message_ts)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)`,
 			[
 				input.id,
 				input.goal,
@@ -34,6 +35,7 @@ export class LoopStore {
 				input.successCommand,
 				input.maxIterations,
 				input.maxCostUsd,
+				input.maxTickDurationMs,
 				input.checkpointInterval ?? null,
 				input.channelId,
 				input.conversationId,

--- a/src/loop/tool.ts
+++ b/src/loop/tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { slackContextStore } from "../agent/slack-context.ts";
 import type { LoopRunner } from "./runner.ts";
 import { parseFrontmatter, readStateFile } from "./state-file.ts";
-import type { Loop } from "./types.ts";
+import { LOOP_MAX_TICK_DURATION_MS, LOOP_MIN_TICK_DURATION_MS, type Loop } from "./types.ts";
 
 export const LOOP_TOOL_NAME = "phantom_loop";
 
@@ -27,6 +27,7 @@ function serializeLoop(loop: Loop): Record<string, unknown> {
 		max_iterations: loop.maxIterations,
 		total_cost_usd: loop.totalCostUsd,
 		max_cost_usd: loop.maxCostUsd,
+		max_tick_duration_minutes: Math.round(loop.maxTickDurationMs / 60_000),
 		started_at: loop.startedAt,
 		last_tick_at: loop.lastTickAt,
 		finished_at: loop.finishedAt,
@@ -55,6 +56,10 @@ ACTIONS:
     workspace (defaults to data/loops/<id>/),
     max_iterations (default 20, hard ceiling 200),
     max_cost_usd (default 5, hard ceiling 50),
+    max_tick_duration_minutes (per-tick wall-clock cap, default 30, min 1,
+      max 60. A tick that exceeds this is hard-cancelled and the loop is
+      finalized as timed_out. Signals do NOT propagate through docker exec,
+      so wrap container commands with the host "timeout" utility),
     checkpoint_interval (run a Sonnet critique every N ticks, 0 or omitted = off),
     success_command (shell command run after each tick; exit 0 = goal
       achieved. Runs under bash -c with a 5 minute timeout in a sanitized env
@@ -73,6 +78,13 @@ regression". Each iteration is fresh - all context must live in the state file.`
 			workspace: z.string().optional(),
 			max_iterations: z.number().int().positive().max(200).optional(),
 			max_cost_usd: z.number().positive().max(50).optional(),
+			max_tick_duration_minutes: z
+				.number()
+				.int()
+				.min(LOOP_MIN_TICK_DURATION_MS / 60_000)
+				.max(LOOP_MAX_TICK_DURATION_MS / 60_000)
+				.optional()
+				.describe("Per-tick wall-clock cap in minutes. Default 30, min 1, max 60."),
 			checkpoint_interval: z
 				.number()
 				.int()
@@ -101,6 +113,8 @@ regression". Each iteration is fresh - all context must live in the state file.`
 							workspace: input.workspace,
 							maxIterations: input.max_iterations,
 							maxCostUsd: input.max_cost_usd,
+							maxTickDurationMs:
+								input.max_tick_duration_minutes !== undefined ? input.max_tick_duration_minutes * 60_000 : undefined,
 							checkpointInterval: input.checkpoint_interval,
 							successCommand: input.success_command,
 							channelId: input.channel_id ?? ctx?.slackChannelId,

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export type LoopStatus = "running" | "done" | "stopped" | "budget_exceeded" | "failed";
+export type LoopStatus = "running" | "done" | "stopped" | "budget_exceeded" | "failed" | "timed_out";
 
 export type Loop = {
 	id: string;
@@ -10,6 +10,7 @@ export type Loop = {
 	successCommand: string | null;
 	maxIterations: number;
 	maxCostUsd: number;
+	maxTickDurationMs: number;
 	checkpointInterval: number | null;
 	status: LoopStatus;
 	iterationCount: number;
@@ -33,6 +34,7 @@ export type LoopRow = {
 	success_command: string | null;
 	max_iterations: number;
 	max_cost_usd: number;
+	max_tick_duration_ms: number;
 	checkpoint_interval: number | null;
 	status: string;
 	iteration_count: number;
@@ -59,6 +61,7 @@ export type LoopStartInput = {
 	workspace?: string;
 	maxIterations?: number;
 	maxCostUsd?: number;
+	maxTickDurationMs?: number;
 	checkpointInterval?: number;
 	successCommand?: string;
 	channelId?: string;
@@ -72,11 +75,25 @@ export const LOOP_MAX_COST_CEILING_USD = 50;
 export const LOOP_DEFAULT_MAX_ITERATIONS = 20;
 export const LOOP_DEFAULT_MAX_COST_USD = 5;
 
+// Per-tick wall-clock bounds. Default 30min matches real-world small/medium ticks
+// (~10min avg), min 1min guards against runaway misconfig, max 60min is the
+// absolute ceiling. Stored internally as ms (setTimeout needs it), exposed on
+// the MCP tool as minutes to match the existing timeout_minutes convention.
+export const LOOP_DEFAULT_MAX_TICK_DURATION_MS = 30 * 60 * 1000;
+export const LOOP_MIN_TICK_DURATION_MS = 60 * 1000;
+export const LOOP_MAX_TICK_DURATION_MS = 60 * 60 * 1000;
+
 export const LoopStartInputSchema = z.object({
 	goal: z.string().min(1).max(10_000),
 	workspace: z.string().optional(),
 	max_iterations: z.number().int().positive().max(LOOP_MAX_ITERATIONS_CEILING).optional(),
 	max_cost_usd: z.number().positive().max(LOOP_MAX_COST_CEILING_USD).optional(),
+	max_tick_duration_minutes: z
+		.number()
+		.int()
+		.min(LOOP_MIN_TICK_DURATION_MS / 60_000)
+		.max(LOOP_MAX_TICK_DURATION_MS / 60_000)
+		.optional(),
 	checkpoint_interval: z.number().int().min(0).max(LOOP_MAX_ITERATIONS_CEILING).optional(),
 	success_command: z.string().optional(),
 	channel_id: z.string().optional(),
@@ -97,6 +114,7 @@ export function rowToLoop(row: LoopRow): Loop {
 		successCommand: row.success_command,
 		maxIterations: row.max_iterations,
 		maxCostUsd: row.max_cost_usd,
+		maxTickDurationMs: row.max_tick_duration_ms,
 		checkpointInterval: row.checkpoint_interval,
 		status: row.status as LoopStatus,
 		iterationCount: row.iteration_count,


### PR DESCRIPTION
## Summary

A loop tick could hang indefinitely when the agent ran a command inside `docker exec` that ignored signals (e.g. `pytest` in a container). The SDK's async iterator never yielded, `LoopRunner.tick()` awaited forever, the `inFlight` set was never released, and every subsequent tick was silently dropped.

This PR bounds every tick in wall-clock time, regardless of what the agent or its subprocesses are doing.

## Design

Two-layer cancel:

1. **Soft cancel** — `AbortController` plumbed through `AgentRuntime.handleMessage` into `runQuery`'s internal controller. Cooperative path for slow-but-responsive ticks.
2. **Hard cancel** — `Promise.race` with a hard-cancel timer in `LoopRunner.tick()`. Escape hatch for wedged subprocesses that ignore signals. On hard cancel, the runner explicitly calls `AgentRuntime.releaseSession()` so the `activeSessions` bookkeeping isn't leaked by the orphan promise.

Budget: **default 30 minutes** (informed by real-world ticks averaging ~10 min on small/medium work), **min 1 minute**, **max 60 minutes**. Exposed on the MCP tool as `max_tick_duration_minutes` to match the existing `timeout_minutes` convention; ms is preserved internally where `setTimeout` needs it.

Timed-out ticks finalize with status `timed_out` and a diagnostic `last_error` including elapsed time, the configured limit, and the last tool that ran. `softTimerFired` is tracked explicitly so post-SDK exceptions can't be misclassified as timeouts.

The agent prompt now instructs wrapping `docker exec` with the host `timeout` utility, since signals don't propagate through `docker exec`.

## Notes on implementation

- **No clamp in `runner.start()` for `maxTickDurationMs`**. The Zod schema at the MCP tool boundary already enforces the 1-60 minute window; runner-level clamping would force soft/hard-timeout tests to wait a full minute. The runner trusts its single internal caller.
- **`softTimerFired` is checked on the success path too**, not just in the catch branch. `AgentRuntime.runQuery` swallows abort errors and returns a normal response with error text, so the race resolves cleanly when the soft timer fires. Without the extra check a timed-out tick would still `recordTick` + re-read the state file.
- **No-op `.catch` on the losing `messagePromise`** so that a later rejection after the hard-timeout wins the race can't become an unhandled-rejection warning.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 1011 pass, 0 fail (includes 5 new runner tests for the timeout paths)
- [x] Manual smoke: `phantom_loop.start` with a wedged shell command (e.g. `sleep 9999` inside `docker exec`), `max_tick_duration_minutes: 1`, `max_iterations: 1`. Verify the loop finalizes as `timed_out` within ~90s with a diagnostic `last_error`.

## Included fix

This branch also cherry-picks `506485d fix: make getListenerCount test resilient to leaked listeners` from PR #16 so CI is green against current `main`. No conflict expected when either PR merges first.