### PR TITLE
feat(runtime): recover gracefully from context window overflow

### DIFF
--- a/src/agent/__tests__/context-overflow.test.ts
+++ b/src/agent/__tests__/context-overflow.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { isContextOverflowError } from "../runtime.ts";
+
+describe("isContextOverflowError", () => {
+	test("detects prompt too long error", () => {
+		expect(isContextOverflowError("prompt is too long: reduce input")).toBe(true);
+		expect(isContextOverflowError("This model's maximum context length is 200000 tokens")).toBe(true);
+	});
+
+	test("detects context_length_exceeded error code", () => {
+		expect(isContextOverflowError("context_length_exceeded")).toBe(true);
+		expect(isContextOverflowError('{"error":{"type":"context_length_exceeded"}}')).toBe(true);
+	});
+
+	test("detects input too long messages", () => {
+		expect(isContextOverflowError("Input is too long for requested operation")).toBe(true);
+	});
+
+	test("detects reduce length hint", () => {
+		expect(isContextOverflowError("Please reduce the length of the messages or completion")).toBe(true);
+	});
+
+	test("detects context window mentions", () => {
+		expect(isContextOverflowError("exceeds the context window limit")).toBe(true);
+	});
+
+	test("is case-insensitive", () => {
+		expect(isContextOverflowError("PROMPT IS TOO LONG")).toBe(true);
+		expect(isContextOverflowError("Context Window Exceeded")).toBe(true);
+	});
+
+	test("does not flag unrelated errors", () => {
+		expect(isContextOverflowError("No conversation found")).toBe(false);
+		expect(isContextOverflowError("rate limit exceeded")).toBe(false);
+		expect(isContextOverflowError("invalid api key")).toBe(false);
+		expect(isContextOverflowError("network error: ECONNRESET")).toBe(false);
+		expect(isContextOverflowError("authentication failed")).toBe(false);
+	});
+
+	test("returns false for empty string", () => {
+		expect(isContextOverflowError("")).toBe(false);
+	});
+});

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -178,8 +178,10 @@ export class AgentRuntime {
 		let resultText = "";
 		let cost: AgentCost = emptyCost();
 		let emittedThinking = false;
+		let toolCallsEmitted = false;
 
-		const runSdkQuery = async (useResume: boolean): Promise<void> => {
+		const runSdkQuery = async (useResume: boolean, contextNote?: string): Promise<void> => {
+			const finalPrompt = contextNote ? `${appendPrompt}\n\n# Session Recovery\n\n${contextNote}` : appendPrompt;
 			const queryStream = query({
 				prompt: text,
 				options: {
@@ -190,7 +192,7 @@ export class AgentRuntime {
 					systemPrompt: {
 						type: "preset" as const,
 						preset: "claude_code" as const,
-						append: appendPrompt,
+						append: finalPrompt,
 					},
 					persistSession: true,
 					effort: this.config.effort,
@@ -232,6 +234,7 @@ export class AgentRuntime {
 						for (const block of message.message.content) {
 							if (block.type === "tool_use") {
 								const toolBlock = block as { name: string; input?: Record<string, unknown> };
+								toolCallsEmitted = true;
 								onEvent?.({
 									type: "tool_use",
 									tool: toolBlock.name,
@@ -258,19 +261,27 @@ export class AgentRuntime {
 			} catch (err: unknown) {
 				const errorMsg = err instanceof Error ? err.message : String(err);
 				const isStaleSession = isResume && errorMsg.includes("No conversation found");
+				// Only attempt overflow recovery on resumed sessions where no tools
+				// have fired yet. A fresh oversized prompt cannot be fixed by retrying
+				// fresh, and retrying after tool activity risks duplicate side effects.
+				const isContextOverflow = !isStaleSession && isResume && !toolCallsEmitted && isContextOverflowError(errorMsg);
 
-				if (isStaleSession) {
-					// SDK session file is gone (container restart, deploy, etc).
-					// Clear the stale reference and retry as a fresh session.
-					console.log(`[runtime] Stale session detected, retrying without resume: ${sessionKey}`);
+				if (isStaleSession || isContextOverflow) {
+					const reason = isStaleSession ? "Stale session" : "Context overflow";
+					console.log(`[runtime] ${reason} detected, retrying as fresh session: ${sessionKey}`);
 					this.sessionStore.clearSdkSessionId(sessionKey);
 					sdkSessionId = "";
 					resultText = "";
 					cost = emptyCost();
 					emittedThinking = false;
+					toolCallsEmitted = false;
+
+					const contextNote = isContextOverflow
+						? "The previous conversation exceeded the context window and was reset. Please continue helping with the original request."
+						: undefined;
 
 					try {
-						await runSdkQuery(false);
+						await runSdkQuery(false, contextNote);
 					} catch (retryErr: unknown) {
 						const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
 						resultText = `Error: ${retryMsg}`;
@@ -349,4 +360,18 @@ function extractCost(message: {
 		outputTokens: totalOutput,
 		modelUsage,
 	};
+}
+
+const CONTEXT_OVERFLOW_PATTERNS = [
+	"prompt is too long",
+	"context_length_exceeded",
+	"input is too long",
+	"reduce the length",
+	"context window",
+	"maximum context length",
+] as const;
+
+export function isContextOverflowError(message: string): boolean {
+	const lower = message.toLowerCase();
+	return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => lower.includes(pattern));
 }


### PR DESCRIPTION
## Summary

- Adds `isContextOverflowError()` detector for Anthropic API "prompt is too long" / context_length_exceeded errors
- Extends the existing stale-session retry block in `runQuery()` to also handle context overflow
- Three safety gates prevent misuse: resumed sessions only, no tool calls emitted, max 1 retry
- Appends a recovery note to the system prompt so the agent knows the session was reset

Adapted from [mutusfa/phantom@b970859](https://github.com/mutusfa/phantom/commit/b970859). Our version adds the `isResume` and `toolCallsEmitted` safety gates that the original did not have.

Co-authored-by: Julius Juodagalvis <julius.juodagalvis@gmail.com>

## Test plan

- [x] 8 new unit tests for `isContextOverflowError` (positive matches, negatives, case insensitivity)
- [x] 1053 existing tests pass, 0 regressions
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] No practical way to trigger 1M token overflow on demand; rely on unit tests and structural parity with the existing stale-session retry path