### PR TITLE
feat: aegis workflow prereqs (constitution + swe role)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data/
 .env.local
 .env
 local/
+docs/plans/
 *.log
 *.db
 *.db-wal

--- a/config/roles/swe.yaml
+++ b/config/roles/swe.yaml
@@ -91,3 +91,180 @@ initial_config:
     Prefer reading existing code before writing new code. Use grep/glob
     to understand structure. Run tests after changes. Check CI before
     marking work as complete.
+
+workflow_spec: |
+  # GitHub Workflow
+
+  These rules apply whenever you commit code to any GitHub repository. They are
+  reinforced by constitution principle 9 and verified server-side by GitHub
+  branch protection plus the Layer 4 CI label-rules check. Mislabeling is a
+  build failure, not a self-discipline question.
+
+  ## Cardinal git rules
+
+  1. Never squash. Never amend. Never force-push. Every commit reaches main with
+     its original SHA.
+  2. All merges into dev and main use --no-ff (merge commit with parent
+     pointers). This creates visible feature-merged boundaries and makes
+     PR-level rollback a single revert.
+  3. Hotfixes are the only branches that touch main directly, and they always
+     also back-merge into dev.
+
+  ## Branches
+
+  - main: production line. Never receives direct pushes. Only dev -> main
+    promotion PRs and hotfix/* PRs land here.
+  - dev: integration line. Receives all feature/fix/chore work via PRs.
+  - Short-lived: feature/<issue>-<slug>, fix/<issue>-<slug>,
+    chore/<issue>-<slug>, docs/<issue>-<slug>, hotfix/<issue>-<slug>. Branched
+    from dev (the first four) or main (hotfix only). Deleted on merge.
+
+  ## Label taxonomy (into dev)
+
+  - auto/docs: CI green -> merge. Docs only. No source code changes.
+  - auto/tests: CI green -> merge. Net-new tests. No production code touched.
+  - auto/chore: CI green -> merge. Lint, formatting, typo fixes, comment cleanup.
+  - auto/refactor: CI green -> merge. Behavior-preserving. Existing tests must
+    already cover the changed code. No public API signature changes.
+  - auto/bugfix: CI green -> merge. Fixes a referenced issue. Must include a
+    regression test in the same PR.
+  - auto/feature-small: CI green -> merge. Must satisfy ALL hard limits below.
+  - review/feature-large: Always reviewed. Anything failing the small-feature
+    limits.
+  - review/risky: Always reviewed plus written justification in the PR body.
+    Touches sensitive paths or carries deliberate risk.
+  - blocked/needs-human: Draft, never merges. You hit a decision you cannot
+    make.
+
+  ## Hard limits for auto/feature-small
+
+  All must be true. Fail any one -> downgrade to review/feature-large.
+
+  - Lines changed (added + removed): <= 150
+  - Files touched: <= 5
+  - New files created: <= 2
+  - New dependencies: 0
+  - Files in sensitive paths: 0
+  - New code has tests in the same PR: required
+  - Touches existing public API signatures: forbidden
+
+  ## Sensitive paths blocklist
+
+  Touching any of these forces review/risky, regardless of label. Hard wall, not
+  heuristic.
+
+  Generic:
+  - .github/
+  - Dockerfile*
+  - docker-compose*
+  - *.env*
+  - secrets/
+  - migrations/
+  - infra/
+  - auth/
+
+  AEGIS-specific:
+  - calibration/ (calibration logic)
+  - safety/ (safety-shutdown logic)
+  - tests/fixtures/astm-* (ASTM compliance test fixtures)
+
+  The exact paths get pinned via `git ls-files` once the AEGIS repo exists, so
+  the list reflects reality, not assumption.
+
+  ## Into main (strict tier)
+
+  Only dev -> main promotion PRs and hotfix/* PRs target main. Both ALWAYS
+  require Josh's review. No labels override this gate.
+
+  ## The label is a claim. CI is the verification.
+
+  You labeling a 400-line change as auto/feature-small is caught by the build,
+  not by your self-discipline. Layer 4 (.github/workflows/label-rules.yml)
+  reads the label, computes the diff, and fails the build if the claim does not
+  match reality. Fix the label or fix the PR.
+
+  ## Promotion model: dev -> main
+
+  Open a promotion PR when ALL FOUR are true:
+
+  1. dev has been CI-green for >= 24 hours.
+  2. No open review/risky PRs against dev.
+  3. No open blocked/needs-human drafts against dev.
+  4. dev is strictly ahead of main.
+
+  Promotion PR shape:
+  - Title: "Promote dev -> main (YYYY-MM-DD)"
+  - Body includes: commit count by label, per-PR summary in merge order with
+    issue links, "## Risky changes" callout listing every review/risky PR that
+    landed since the last promotion, "## Test counts" pre vs post (must match
+    exactly, no quietly-added skips), "## Diff stats" total LOC and files
+    touched.
+
+  Gating: Josh merges. That is the only gate. You never merge your own
+  promotion PR. After Josh merges, dev is NOT deleted (it keeps moving). You do
+  NOT auto-open the next promotion PR; wait for the soak conditions to
+  re-trigger.
+
+  PR rot protection: only one promotion PR open at a time. If a new soak window
+  opens while a previous promotion PR is still un-merged:
+  1. Comment on the old PR: "Superseded by #N - fresher changes available,
+     closing this".
+  2. Close the old PR.
+  3. Open the fresh promotion PR.
+
+  ## Hotfix path
+
+  main is broken. Waiting for the next promotion is unacceptable.
+
+  1. Open hotfix/<issue>-<slug> branched from main.
+  2. PR targets main (not dev) with label review/risky. No override possible.
+  3. Write the fix, open the PR, run CI, AND STOP.
+  4. Josh merges to main.
+  5. Immediately after the main merge, open a back-port PR:
+     hotfix/<issue>-<slug> -> dev.
+  6. If the back-merge applies cleanly: label it auto/bugfix and let it
+     auto-merge.
+  7. If there is a conflict: open the back-port as draft with
+     blocked/needs-human and a comment explaining which files conflicted. Do
+     NOT improvise around merge conflicts.
+
+  ## Issues workflow
+
+  Cardinal rule: every PR references an issue. No drive-by PRs. Even a one-line
+  typo fix gets a one-line issue first. The issue may exist for 30 seconds
+  before the PR closes it. The audit trail says every change traces to a
+  captured intent.
+
+  Categories you are allowed to file:
+  - bug/test-failure: a test is failing on dev or main that was not failing
+    before
+  - bug/regression: behavior changed unintentionally (tied to a specific commit
+    SHA)
+  - bug/broken-doc-link: a link in docs/ 404s
+  - chore/dead-code: unreachable code you found while working
+  - chore/todo: a TODO or FIXME comment you encountered
+  - chore/lint: lint or formatter violations you can fix automatically
+  - chore/dependency-bump: a dep has a patch-level update. You may FILE the
+    issue. You may NOT open a PR from it. Dependency bumps are handled by
+    Josh manually until a Dependabot-equivalent flow is designed.
+
+  Categories you are FORBIDDEN from filing: anything that smells like a
+  feature, an enhancement, a refactor-as-feature, a "what if we added X," or a
+  design decision. If you notice something you think should exist but it is
+  not a bug or chore, surface it to Josh in conversation: "I noticed X while
+  working on Y - want me to file it?" Josh decides. Josh files. This is the
+  guardrail against you inventing scope.
+
+  Issue templates: .github/ISSUE_TEMPLATE/*.yml force fields you cannot fudge
+  (first broken commit SHA for regressions, test name and failure output for
+  test failures, file paths plus grep proof for dead-code, package and version
+  links for dependency bumps). No template, no issue. You cannot file via raw
+  API without filling the template fields.
+
+  Closing rules:
+  - Your own filed issue -> closed by the PR that fixes it (linked via
+    "Closes #N").
+  - User-filed issue -> closed only when its PR is merged.
+  - You NEVER close a user-filed issue by comment, even if you disagree. If
+    you think an issue is wrong, comment with your reasoning and wait.
+  - Stale issues are not auto-closed. No stale-bot.

--- a/phantom-config/constitution.md
+++ b/phantom-config/constitution.md
@@ -18,3 +18,5 @@ Any proposed change that conflicts with these principles is rejected.
 7. Consent: You do not modify your own constitution, rollback mechanisms, logging systems, or evolution engine. These are outside your scope of self-modification.
 
 8. Proportionality: Changes should be minimal and targeted. Do not rewrite broad sections because of one correction. Each change addresses a specific observation.
+
+9. Workflow: When committing to any GitHub repo, you must follow the workflow rules in your role's systemPromptSection. Mislabeling a PR, bypassing the human merge gate, or modifying branch protection are constitution violations. The workflow rules are not subject to evolution.

--- a/src/agent/__tests__/prompt-assembler.test.ts
+++ b/src/agent/__tests__/prompt-assembler.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { PhantomConfig } from "../../config/types.ts";
+import { loadRoleFromYaml } from "../../roles/loader.ts";
 import { assemblePrompt } from "../prompt-assembler.ts";
 
 const baseConfig: PhantomConfig = {
@@ -113,5 +114,32 @@ describe("assemblePrompt constitution injection", () => {
 		writeFileSync(join(TEST_CONFIG_DIR, "constitution.md"), "");
 		const prompt = assemblePrompt(baseConfig, undefined, undefined, undefined, undefined, undefined, TEST_CONFIG_DIR);
 		expect(prompt).not.toContain("# Constitution\n\n");
+	});
+});
+
+describe("assemblePrompt end-to-end with real SWE role", () => {
+	test("assembled prompt for the SWE role contains constitution principle 9 and workflow spec", () => {
+		const role = loadRoleFromYaml("swe", resolve("config/roles"));
+		const prompt = assemblePrompt(baseConfig, undefined, undefined, role);
+
+		// Constitution made it in
+		expect(prompt).toContain("# Constitution");
+		expect(prompt).toContain("9. Workflow");
+
+		// Workflow spec made it in
+		expect(prompt).toContain("# Workflow");
+		expect(prompt).toContain("Never squash");
+		expect(prompt).toContain("auto/feature-small");
+		expect(prompt).toContain("hotfix/");
+		expect(prompt).toContain("Promote dev");
+		expect(prompt).toContain("every PR references an issue");
+
+		// Ordering: security -> constitution -> role (which contains workflow)
+		const securityIdx = prompt.indexOf("Security Boundaries");
+		const constitutionIdx = prompt.indexOf("# Constitution");
+		const workflowIdx = prompt.indexOf("# Workflow");
+		expect(securityIdx).toBeGreaterThan(-1);
+		expect(constitutionIdx).toBeGreaterThan(securityIdx);
+		expect(workflowIdx).toBeGreaterThan(constitutionIdx);
 	});
 });

--- a/src/agent/__tests__/prompt-assembler.test.ts
+++ b/src/agent/__tests__/prompt-assembler.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { PhantomConfig } from "../../config/types.ts";
 import { assemblePrompt } from "../prompt-assembler.ts";
 
@@ -70,5 +72,46 @@ describe("assemblePrompt Docker awareness", () => {
 		expect(prompt).toContain("Full Bash access");
 		expect(prompt).toContain("phantom_register_tool");
 		expect(prompt).toContain("Security Boundaries");
+	});
+});
+
+describe("assemblePrompt constitution injection", () => {
+	const TEST_CONFIG_DIR = join(import.meta.dir, ".test-prompt-assembler-config");
+
+	beforeEach(() => {
+		mkdirSync(TEST_CONFIG_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+	});
+
+	test("injects constitution.md as a top-level section after security", () => {
+		writeFileSync(
+			join(TEST_CONFIG_DIR, "constitution.md"),
+			"# Phantom Constitution\n\n1. Honesty: do not lie.\n9. Workflow: follow role workflow rules.\n",
+		);
+
+		const prompt = assemblePrompt(baseConfig, undefined, undefined, undefined, undefined, undefined, TEST_CONFIG_DIR);
+
+		expect(prompt).toContain("# Constitution");
+		expect(prompt).toContain("1. Honesty: do not lie.");
+		expect(prompt).toContain("9. Workflow: follow role workflow rules.");
+
+		const securityIdx = prompt.indexOf("Security Boundaries");
+		const constitutionIdx = prompt.indexOf("# Constitution");
+		expect(securityIdx).toBeGreaterThan(-1);
+		expect(constitutionIdx).toBeGreaterThan(securityIdx);
+	});
+
+	test("omits constitution section when file is missing", () => {
+		const prompt = assemblePrompt(baseConfig, undefined, undefined, undefined, undefined, undefined, TEST_CONFIG_DIR);
+		expect(prompt).not.toContain("# Constitution\n\n# Phantom Constitution");
+	});
+
+	test("omits constitution section when file is empty", () => {
+		writeFileSync(join(TEST_CONFIG_DIR, "constitution.md"), "");
+		const prompt = assemblePrompt(baseConfig, undefined, undefined, undefined, undefined, undefined, TEST_CONFIG_DIR);
+		expect(prompt).not.toContain("# Constitution\n\n");
 	});
 });

--- a/src/agent/__tests__/prompt-assembler.test.ts
+++ b/src/agent/__tests__/prompt-assembler.test.ts
@@ -107,7 +107,7 @@ describe("assemblePrompt constitution injection", () => {
 
 	test("omits constitution section when file is missing", () => {
 		const prompt = assemblePrompt(baseConfig, undefined, undefined, undefined, undefined, undefined, TEST_CONFIG_DIR);
-		expect(prompt).not.toContain("# Constitution\n\n# Phantom Constitution");
+		expect(prompt).not.toContain("# Constitution");
 	});
 
 	test("omits constitution section when file is empty", () => {

--- a/src/agent/prompt-assembler.ts
+++ b/src/agent/prompt-assembler.ts
@@ -267,10 +267,6 @@ function buildSecurity(): string {
 function buildEvolvedSections(evolved: EvolvedConfig): string {
 	const parts: string[] = [];
 
-	if (evolved.constitution.trim()) {
-		parts.push(`# Constitution\n\n${evolved.constitution.trim()}`);
-	}
-
 	if (evolved.persona.trim() && countContentLines(evolved.persona) > 1) {
 		parts.push(`# Communication Style\n\n${evolved.persona.trim()}`);
 	}

--- a/src/agent/prompt-assembler.ts
+++ b/src/agent/prompt-assembler.ts
@@ -11,6 +11,7 @@ export function assemblePrompt(
 	roleTemplate?: RoleTemplate,
 	onboardingPrompt?: string,
 	dataDir?: string,
+	configDir?: string,
 ): string {
 	const sections: string[] = [];
 
@@ -22,6 +23,13 @@ export function assemblePrompt(
 
 	// 3. Security - what you must never do
 	sections.push(buildSecurity());
+
+	// 3a. Constitution - immutable principles loaded from phantom-config/constitution.md
+	const resolvedConfigDir = configDir ?? join(process.cwd(), "phantom-config");
+	const constitution = buildConstitution(resolvedConfigDir);
+	if (constitution) {
+		sections.push(constitution);
+	}
 
 	// 4. Role-specific prompt section (detailed identity, capabilities, communication)
 	if (roleTemplate) {
@@ -398,4 +406,16 @@ function countContentLines(text: string): number {
 		const trimmed = line.trim();
 		return trimmed !== "" && !trimmed.startsWith("#");
 	}).length;
+}
+
+function buildConstitution(configDir: string): string {
+	const path = join(configDir, "constitution.md");
+	try {
+		if (!existsSync(path)) return "";
+		const content = readFileSync(path, "utf-8").trim();
+		if (!content) return "";
+		return `# Constitution\n\n${content}`;
+	} catch {
+		return "";
+	}
 }

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -28,6 +28,7 @@ export class AgentRuntime {
 	private roleTemplate: RoleTemplate | null = null;
 	private onboardingPrompt: string | null = null;
 	private lastTrackedFiles: string[] = [];
+	private configDir: string | null = null;
 	private mcpServerFactories: Record<string, () => McpServerConfig> | null = null;
 
 	constructor(config: PhantomConfig, db: Database) {
@@ -50,6 +51,10 @@ export class AgentRuntime {
 
 	setOnboardingPrompt(prompt: string | null): void {
 		this.onboardingPrompt = prompt;
+	}
+
+	setConfigDir(dir: string): void {
+		this.configDir = dir;
 	}
 
 	setMcpServerFactories(factories: Record<string, () => McpServerConfig>): void {
@@ -155,6 +160,7 @@ export class AgentRuntime {
 			this.roleTemplate ?? undefined,
 			this.onboardingPrompt ?? undefined,
 			undefined,
+			this.configDir ?? undefined,
 		);
 		const controller = new AbortController();
 		const timeoutMs = (this.config.timeout_minutes ?? 240) * 60 * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ async function main(): Promise<void> {
 
 	if (evolution) {
 		runtime.setEvolvedConfig(evolution.getConfig());
+		runtime.setConfigDir(evolution.getEvolutionConfig().paths.config_dir);
 	}
 
 	// Wire feedback to evolution engine

--- a/src/onboarding/__tests__/flow.test.ts
+++ b/src/onboarding/__tests__/flow.test.ts
@@ -13,6 +13,7 @@ const mockRole: RoleTemplate = {
 	identity: "You are a software engineer.",
 	capabilities: ["Write code"],
 	communication: "Concise and technical.",
+	workflow_spec: "",
 	onboarding_questions: [],
 	mcp_tools: [],
 	evolution_focus: { priorities: ["coding_patterns"], feedback_signals: [] },

--- a/src/onboarding/__tests__/prompt.test.ts
+++ b/src/onboarding/__tests__/prompt.test.ts
@@ -10,6 +10,7 @@ const mockRole: RoleTemplate = {
 	identity: "You are a software engineer.",
 	capabilities: ["Write code"],
 	communication: "Concise and technical.",
+	workflow_spec: "",
 	onboarding_questions: [],
 	mcp_tools: [],
 	evolution_focus: { priorities: ["coding_patterns"], feedback_signals: [] },

--- a/src/roles/__tests__/loader.test.ts
+++ b/src/roles/__tests__/loader.test.ts
@@ -148,6 +148,55 @@ evolution_focus:
 		expect(() => loadRoleFromYaml("badq", TEST_DIR)).toThrow("Invalid role config");
 	});
 
+	test("appends workflow_spec to systemPromptSection under a Workflow heading", () => {
+		writeFileSync(
+			join(TEST_DIR, "withwf.yaml"),
+			`id: withwf
+name: With Workflow
+description: Has a workflow spec.
+identity: You enforce workflows.
+capabilities:
+  - Enforce things
+communication: Direct.
+workflow_spec: |
+  # GitHub Workflow
+
+  Never squash. Never amend. Never force-push.
+evolution_focus:
+  priorities:
+    - workflow_compliance
+`,
+		);
+
+		const template = loadRoleFromYaml("withwf", TEST_DIR);
+
+		expect(template.systemPromptSection).toContain("# Workflow");
+		expect(template.systemPromptSection).toContain("Never squash. Never amend. Never force-push.");
+		const commIdx = template.systemPromptSection.indexOf("# Communication Style");
+		const wfIdx = template.systemPromptSection.indexOf("# Workflow");
+		expect(commIdx).toBeGreaterThan(-1);
+		expect(wfIdx).toBeGreaterThan(commIdx);
+	});
+
+	test("omits Workflow heading when workflow_spec is empty", () => {
+		writeFileSync(
+			join(TEST_DIR, "nowf.yaml"),
+			`id: nowf
+name: No Workflow
+description: No workflow.
+identity: You have no workflow.
+capabilities:
+  - Nothing
+communication: Whatever.
+evolution_focus:
+  priorities:
+    - nothing
+`,
+		);
+		const template = loadRoleFromYaml("nowf", TEST_DIR);
+		expect(template.systemPromptSection).not.toContain("# Workflow");
+	});
+
 	test("validates evolution_focus has at least one priority", () => {
 		writeFileSync(
 			join(TEST_DIR, "noprio.yaml"),

--- a/src/roles/__tests__/registry.test.ts
+++ b/src/roles/__tests__/registry.test.ts
@@ -14,6 +14,7 @@ function makeTemplate(overrides: Partial<RoleTemplate> = {}): RoleTemplate {
 		identity: "You are a test agent.",
 		capabilities: ["Testing things"],
 		communication: "Be direct.",
+		workflow_spec: "",
 		onboarding_questions: [],
 		mcp_tools: [],
 		evolution_focus: { priorities: ["testing"], feedback_signals: [] },

--- a/src/roles/__tests__/swe.test.ts
+++ b/src/roles/__tests__/swe.test.ts
@@ -100,6 +100,44 @@ describe("SWE Role", () => {
 		expect(swe.systemPromptSection).toContain("# Capabilities");
 		expect(swe.systemPromptSection).toContain("# Communication Style");
 	});
+
+	test("loads the AEGIS workflow spec into systemPromptSection", () => {
+		const swe = loadRoleFromYaml("swe", ROLES_DIR);
+
+		expect(swe.systemPromptSection).toContain("# Workflow");
+
+		// Cardinal git rules
+		expect(swe.systemPromptSection).toContain("Never squash");
+		expect(swe.systemPromptSection).toContain("Never amend");
+		expect(swe.systemPromptSection).toContain("Never force-push");
+		expect(swe.systemPromptSection).toContain("--no-ff");
+
+		// Branch model
+		expect(swe.systemPromptSection).toContain("main");
+		expect(swe.systemPromptSection).toContain("dev");
+		expect(swe.systemPromptSection).toContain("hotfix/");
+
+		// Label taxonomy
+		expect(swe.systemPromptSection).toContain("auto/feature-small");
+		expect(swe.systemPromptSection).toContain("review/risky");
+		expect(swe.systemPromptSection).toContain("blocked/needs-human");
+
+		// Hard limits for auto/feature-small
+		expect(swe.systemPromptSection).toContain("150");
+		expect(swe.systemPromptSection).toContain("Files touched");
+
+		// Sensitive paths
+		expect(swe.systemPromptSection).toContain("calibration/");
+		expect(swe.systemPromptSection).toContain("safety/");
+		expect(swe.systemPromptSection).toContain(".github/");
+
+		// Promotion model
+		expect(swe.systemPromptSection).toContain("Promote dev");
+		expect(swe.systemPromptSection).toContain("24");
+
+		// Issues workflow
+		expect(swe.systemPromptSection).toContain("every PR references an issue");
+	});
 });
 
 describe("Base Role", () => {

--- a/src/roles/loader.ts
+++ b/src/roles/loader.ts
@@ -61,6 +61,7 @@ function buildSystemPromptSection(config: {
 	identity: string;
 	capabilities: string[];
 	communication: string;
+	workflow_spec: string;
 }): string {
 	const parts: string[] = [];
 
@@ -72,6 +73,10 @@ function buildSystemPromptSection(config: {
 	}
 
 	parts.push(`# Communication Style\n\n${config.communication}`);
+
+	if (config.workflow_spec.trim()) {
+		parts.push(`# Workflow\n\n${config.workflow_spec.trim()}`);
+	}
 
 	return parts.join("\n\n");
 }

--- a/src/roles/types.ts
+++ b/src/roles/types.ts
@@ -41,6 +41,7 @@ export const RoleConfigSchema = z.object({
 	identity: z.string().min(1),
 	capabilities: z.array(z.string().min(1)).min(1),
 	communication: z.string().min(1),
+	workflow_spec: z.string().default(""),
 	onboarding_questions: z.array(OnboardingQuestionSchema).default([]),
 	mcp_tools: z.array(McpToolDefinitionSchema).default([]),
 	evolution_focus: EvolutionFocusSchema,


### PR DESCRIPTION
## Summary
- Add principle 9 (workflow compliance) to `phantom-config/constitution.md`
- Inject `constitution.md` as a top-level prompt section after security boundaries (Layer 1)
- Remove duplicate constitution injection from `buildEvolvedSections` (was reading the same file twice)
- Add `workflow_spec` field to role config schema (`z.string().default("")`)
- Write the full AEGIS GitHub workflow spec into the SWE role template (Layer 2)
- Wire `configDir` through `AgentRuntime` so constitution injection uses the correct path with non-default config directories

## Why
Layers 1 and 2 of the AEGIS four-layer enforcement wall live in the Phantom repo. Phantom can't deliver code to AEGIS under the strict workflow until it carries those rules in its system prompt every session. Design doc: `docs/plans/2026-04-11-aegis-github-workflow-design.md`.

## What changed
- `phantom-config/constitution.md` - principle 9 added
- `src/agent/prompt-assembler.ts` - `configDir` param, `buildConstitution()` helper, removed evolved duplicate
- `src/agent/runtime.ts` - `setConfigDir()` method, passes configDir to assemblePrompt
- `src/index.ts` - wires evolution config_dir to runtime
- `src/roles/types.ts` - `workflow_spec` field on `RoleConfigSchema`
- `src/roles/loader.ts` - `buildSystemPromptSection` appends `# Workflow` heading
- `config/roles/swe.yaml` - full AEGIS workflow spec (cardinal git rules, branch model, label taxonomy, hard limits, sensitive paths, promotion model, hotfix path, issues workflow)
- `.gitignore` - ignore docs/plans/

## Test plan
- [x] `bun test` - 1067 tests pass (5 new tests added)
- [x] `bun run lint` - clean
- [x] `bun run typecheck` - clean
- [x] End-to-end test: real SWE role through assembler confirms constitution + workflow spec present and correctly ordered
- [x] Dual independent review for bugs/regressions - no issues found