### PR TITLE
feat(github-templates): canonical issue template scaffolding

### DIFF
--- a/config/github-templates/ISSUE_TEMPLATE/bug-broken-doc-link.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/bug-broken-doc-link.yml
@@ -1,0 +1,49 @@
+name: "Bug: broken doc link"
+description: A link inside the repo's documentation returns 404 or points to the wrong target.
+title: "[bug/broken-doc-link] "
+labels:
+  - "bug/broken-doc-link"
+body:
+  - type: input
+    id: source-file
+    attributes:
+      label: Source file containing the broken link
+      description: Path relative to repo root, with the line number.
+      placeholder: "docs/architecture.md:142"
+    validations:
+      required: true
+  - type: input
+    id: broken-url
+    attributes:
+      label: The broken link, verbatim
+      description: Exactly as it appears in the source file (markdown or raw URL).
+      placeholder: "[Memory](./memory-old.md)"
+    validations:
+      required: true
+  - type: dropdown
+    id: failure-mode
+    attributes:
+      label: How is it broken?
+      options:
+        - "404 (target does not exist)"
+        - "wrong target (resolves, but to the wrong page)"
+        - "anchor missing (page exists, #fragment does not)"
+        - "external URL dead"
+    validations:
+      required: true
+  - type: input
+    id: expected-target
+    attributes:
+      label: Expected target (if known)
+      description: Path or URL the link should point to. Leave blank if unclear.
+      placeholder: "docs/memory.md"
+    validations:
+      required: false
+  - type: textarea
+    id: verification
+    attributes:
+      label: How the break was verified
+      description: Command output, curl response, or manual navigation steps. One-liner is fine.
+      render: text
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/bug-regression.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/bug-regression.yml
@@ -1,0 +1,51 @@
+name: "Bug: regression"
+description: Behavior changed unintentionally. Tied to a specific commit.
+title: "[bug/regression] "
+labels:
+  - "bug/regression"
+body:
+  - type: textarea
+    id: prior-behavior
+    attributes:
+      label: Prior behavior (what used to happen)
+      description: One paragraph. State it in terms a stranger could verify.
+    validations:
+      required: true
+  - type: textarea
+    id: new-behavior
+    attributes:
+      label: New behavior (what happens now)
+      description: One paragraph. Same bar as above.
+    validations:
+      required: true
+  - type: input
+    id: first-broken-sha
+    attributes:
+      label: First broken commit SHA
+      description: Full 40-character SHA identified via bisect or diff inspection. Required. No "somewhere after X" allowed.
+      placeholder: "a4a86795b2c3..."
+    validations:
+      required: true
+  - type: input
+    id: last-good-sha
+    attributes:
+      label: Last known-good commit SHA
+      description: Full 40-character SHA where prior behavior was confirmed.
+      placeholder: "e44301e9..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Exact steps, starting from `git checkout <first-broken-sha>`. Include any commands, inputs, and expected vs actual output.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence this is a regression (not a new bug)
+      description: Pointer to the prior test, log, spec, or commit message that documented the old behavior. "I remember it worked" is not evidence.
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/bug-test-failure.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/bug-test-failure.yml
@@ -1,0 +1,56 @@
+name: "Bug: test failure"
+description: A test is failing on dev or main that was not failing before.
+title: "[bug/test-failure] "
+labels:
+  - "bug/test-failure"
+body:
+  - type: input
+    id: test-name
+    attributes:
+      label: Fully qualified test name
+      description: The exact identifier the test runner prints. Path plus test name.
+      placeholder: "src/memory/episodic.test.ts > hybrid search > returns BM25 + dense results"
+    validations:
+      required: true
+  - type: input
+    id: branch
+    attributes:
+      label: Branch where the failure was observed
+      placeholder: "dev"
+    validations:
+      required: true
+  - type: input
+    id: first-failing-commit
+    attributes:
+      label: First commit SHA observed failing
+      description: Full 40-character SHA. Leave blank only if the failure predates the branch.
+      placeholder: "a4a86795b2c3..."
+    validations:
+      required: false
+  - type: textarea
+    id: failure-output
+    attributes:
+      label: Raw failure output
+      description: Paste the runner output verbatim. Do not summarize. Include stack trace if any.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction command
+      description: Exact shell command that reproduces the failure from a clean checkout.
+      render: bash
+      placeholder: "bun test src/memory/episodic.test.ts"
+    validations:
+      required: true
+  - type: dropdown
+    id: deterministic
+    attributes:
+      label: Deterministic?
+      options:
+        - "yes, fails every run"
+        - "flaky, fails intermittently"
+        - "unknown"
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/chore-dead-code.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/chore-dead-code.yml
@@ -1,0 +1,45 @@
+name: "Chore: dead code"
+description: Unreachable or unused code encountered while working. Ripe for deletion.
+title: "[chore/dead-code] "
+labels:
+  - "chore/dead-code"
+body:
+  - type: textarea
+    id: paths
+    attributes:
+      label: File paths (one per line)
+      description: Paths relative to repo root. Include line ranges where applicable.
+      placeholder: |
+        src/legacy/old-parser.ts
+        src/agent/runtime.ts:412-438
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Kind of dead code
+      options:
+        - "exported symbol, zero importers"
+        - "private function, zero callers"
+        - "conditional branch unreachable (flag/constant)"
+        - "entire file unreferenced"
+        - "commented-out block"
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof of unreachability
+      description: Command output showing zero references. Grep output, compiler/linter warning, or coverage report. "I looked and nothing uses it" is not proof.
+      render: text
+      placeholder: "$ rg 'oldParser' --type ts\n(no output)"
+    validations:
+      required: true
+  - type: textarea
+    id: history
+    attributes:
+      label: Why it was there (if discoverable)
+      description: Last commit to touch these lines. Helps judge whether deletion is safe or is removing someone's in-progress work.
+      placeholder: "Last touched in commit a4a8679 (2026-03-15) — feature flag rollout, flag has since been removed."
+    validations:
+      required: false

--- a/config/github-templates/ISSUE_TEMPLATE/chore-dependency-bump.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/chore-dependency-bump.yml
@@ -1,0 +1,74 @@
+name: "Chore: dependency bump"
+description: An upstream dependency has a newer release. Files the intent. Does not imply auto-PR.
+title: "[chore/dependency-bump] "
+labels:
+  - "chore/dependency-bump"
+body:
+  - type: input
+    id: package
+    attributes:
+      label: Package name
+      description: Exactly as it appears in the lockfile or manifest.
+      placeholder: "@anthropic-ai/claude-agent-sdk"
+    validations:
+      required: true
+  - type: input
+    id: ecosystem
+    attributes:
+      label: Ecosystem
+      description: Which package manager / registry.
+      placeholder: "npm, cargo, pip, go, brew, apt"
+    validations:
+      required: true
+  - type: input
+    id: current-version
+    attributes:
+      label: Current version
+      description: Exact version pinned in the lockfile. No ranges.
+      placeholder: "0.4.2"
+    validations:
+      required: true
+  - type: input
+    id: target-version
+    attributes:
+      label: Target version
+      description: Exact version being proposed. No ranges.
+      placeholder: "0.4.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: semver-kind
+    attributes:
+      label: SemVer kind
+      options:
+        - "patch (0.0.x)"
+        - "minor (0.x.0)"
+        - "major (x.0.0)"
+        - "pre-release"
+    validations:
+      required: true
+  - type: input
+    id: changelog-url
+    attributes:
+      label: Upstream changelog URL
+      description: Direct link to the release notes or CHANGELOG entry for the target version. "GitHub release" page or the repo's CHANGELOG.md anchor. Required.
+      placeholder: "https://github.com/anthropics/anthropic-sdk-typescript/releases/tag/v0.4.3"
+    validations:
+      required: true
+  - type: textarea
+    id: notable-changes
+    attributes:
+      label: Notable changes between current and target
+      description: Short summary pulled from the changelog. Call out any breaking changes, deprecations, or security fixes. If changelog is empty, say so.
+    validations:
+      required: true
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Breaking changes?
+      options:
+        - "none"
+        - "yes, documented in changelog"
+        - "unclear"
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/chore-lint.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/chore-lint.yml
@@ -1,0 +1,54 @@
+name: "Chore: lint or formatter violation"
+description: Lint, formatter, or type-check violations the agent can fix automatically.
+title: "[chore/lint] "
+labels:
+  - "chore/lint"
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Which tool flagged it?
+      options:
+        - "biome (lint)"
+        - "biome (format)"
+        - "tsc (typecheck)"
+        - "prettier"
+        - "eslint"
+        - "other (specify in output block)"
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Reproduction command
+      description: Exact command from repo root. Must produce the output below on a clean checkout.
+      render: bash
+      placeholder: "bun run lint"
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Tool output
+      description: Paste the violations verbatim. Include file paths, rule names, and line numbers. Do not summarize.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: fix-mode
+    attributes:
+      label: Fix mode
+      options:
+        - "auto-fixable (tool's --fix flag resolves all violations)"
+        - "partially auto-fixable (some manual edits required)"
+        - "manual only"
+    validations:
+      required: true
+  - type: input
+    id: file-count
+    attributes:
+      label: Files affected
+      description: Integer count. Helps size the PR.
+      placeholder: "3"
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/chore-todo.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/chore-todo.yml
@@ -1,0 +1,52 @@
+name: "Chore: TODO or FIXME"
+description: A TODO or FIXME comment encountered in the source.
+title: "[chore/todo] "
+labels:
+  - "chore/todo"
+body:
+  - type: input
+    id: location
+    attributes:
+      label: File and line
+      description: Path and line number where the comment lives.
+      placeholder: "src/evolution/engine.ts:284"
+    validations:
+      required: true
+  - type: dropdown
+    id: marker
+    attributes:
+      label: Marker kind
+      options:
+        - "TODO"
+        - "FIXME"
+        - "XXX"
+        - "HACK"
+        - "NOTE (action-bearing)"
+    validations:
+      required: true
+  - type: textarea
+    id: comment-text
+    attributes:
+      label: The comment, verbatim
+      description: Paste the full comment including surrounding lines for context.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-action
+    attributes:
+      label: Proposed action
+      description: What resolving this looks like. Delete the comment? Implement the missing piece? Link to a design doc? Must be concrete.
+    validations:
+      required: true
+  - type: dropdown
+    id: blast-radius
+    attributes:
+      label: Blast radius if acted on
+      options:
+        - "local (touches one function)"
+        - "module (touches one file or tight cluster)"
+        - "cross-module (touches multiple subsystems)"
+        - "unknown"
+    validations:
+      required: true

--- a/config/github-templates/ISSUE_TEMPLATE/config.yml
+++ b/config/github-templates/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary
- Adds 7 stricter/generic issue templates under `config/github-templates/ISSUE_TEMPLATE/` covering the AEGIS workflow's allowed `bug/*` and `chore/*` categories.
- Adds `config.yml` with `blank_issues_enabled: false` so only templated issues can be filed.
- Templates are intentionally more rigorous than the aegis-backend drafts so they can travel to future Phantom-managed repos without per-repo tuning (Layer 1/2 canonical scaffolding).

## Context
Follow-up to PR #27 (GitHub App integration). Originally authored 2026-04-17 but never committed. Kept as canonical scaffolding while aegis-backend uses its own less-strict copies. Distribution mechanism (bootstrap MCP tool) is future work.

## Test plan
- [ ] Visual review of the 8 YAML files
- [ ] Confirm no code paths import these files (they are static assets for future repo bootstrapping)